### PR TITLE
Improve tum live names

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -23,7 +23,8 @@
   "permissions": [
     "webRequest",
     "tabs",
-    "storage"
+    "storage",
+    "scripting"
   ],
   "host_permissions": [
     "https://tum.cloud.panopto.eu/*",

--- a/src/components/VideoTable.tsx
+++ b/src/components/VideoTable.tsx
@@ -79,10 +79,10 @@ class VideoTableRow extends React.Component<VideoTableRowProps, VideoTableRowSta
                             defaultValue={this.props.video.title}
                         />
                     ) : (
-                        <Tooltip title={this.props.video.title}>
+                        <Tooltip title={this.props.video.title} placement="top">
                             <Typography
                                 variant="body2"
-                                sx={{ fontWeight: "bold", maxWidth: 250, minWidth: 250, pr: 0 }}
+                                sx={{ fontWeight: "bold", maxWidth: 300, minWidth: 300, pr: 0 }}
                                 noWrap={true}
                             >
                                 {this.props.video.title}


### PR DESCRIPTION
 - add better tum live names by injecting a script to collect data from the video page (previously only the tab title was used)
 - add name collision resolving in case there are several videos with the same file name in a download all command

Closes #7.